### PR TITLE
[codex] CI の npm 固定（11.10.0）を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
           node-version: "24.13"
           cache: "npm"
           cache-dependency-path: package-lock.json
+      - name: Use npm 11.10.0
+        run: npm i -g npm@11.10.0
       - name: Install dependencies
         run: npm ci
       - name: Run lint
@@ -29,6 +31,8 @@ jobs:
           node-version: "24.13"
           cache: "npm"
           cache-dependency-path: package-lock.json
+      - name: Use npm 11.10.0
+        run: npm i -g npm@11.10.0
       - name: Install dependencies
         run: npm ci
       - name: Run test

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -28,6 +28,8 @@ jobs:
           node-version: "24.13"
           cache: "npm"
           cache-dependency-path: package-lock.json
+      - name: Use npm 11.10.0
+        run: npm i -g npm@11.10.0
       - name: Build
         run: npm ci && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0


### PR DESCRIPTION
## 概要
- actions/setup-node の直後に npm 11.10.0 を固定するステップを追加
- npm を利用する workflow に適用

## 目的
- min-release-age を利用できる npm バージョンを CI で安定して使うため