### PR TITLE
推奨環境表記を追加

### DIFF
--- a/src/lib/components/RecommendedEnvironment.spec.ts
+++ b/src/lib/components/RecommendedEnvironment.spec.ts
@@ -1,0 +1,48 @@
+import { render, waitFor } from "@testing-library/svelte";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import Component from "$lib/components/RecommendedEnvironment.svelte";
+
+describe("RecommendedEnvironment", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test("推奨環境の案内文が表示される", () => {
+		const { container } = render(Component);
+
+		expect(
+			container.querySelector("[data-itemname='recommended-environment']")!
+				.textContent,
+		).toContain("IE5.5 / 800×600");
+	});
+
+	test("IEの場合は警告が表示されない", async () => {
+		vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(
+			"Mozilla/4.0 (compatible; MSIE 5.5; Windows NT)",
+		);
+		const { container } = render(Component);
+
+		await waitFor(() => {
+			expect(
+				container.querySelector(
+					"[data-itemname='recommended-environment-warning']",
+				),
+			).toBeNull();
+		});
+	});
+
+	test("IE以外の場合は警告が表示される", async () => {
+		vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(
+			"Mozilla/5.0 (Macintosh; Intel Mac OS X) Chrome/1.0",
+		);
+		const { container } = render(Component);
+
+		await waitFor(() => {
+			expect(
+				container.querySelector(
+					"[data-itemname='recommended-environment-warning']",
+				),
+			).not.toBeNull();
+		});
+	});
+});

--- a/src/lib/components/RecommendedEnvironment.svelte
+++ b/src/lib/components/RecommendedEnvironment.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+import { onMount } from "svelte";
+
+let isRecommended = true;
+
+onMount(() => {
+	isRecommended = window.navigator.userAgent.includes("MSIE");
+});
+</script>
+
+<div class="mx-auto my-2 text-xs" data-itemname="recommended-environment">
+  <div>このサイトは IE5.5 / 800×600 でご覧ください。</div>
+  <div>Sorry, This site is Japanese only.</div>
+  {#if !isRecommended}
+    <div class="mt-1 text-red-500" data-itemname="recommended-environment-warning">
+      ※推奨環境外のブラウザです※
+    </div>
+  {/if}
+</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@ import { onMount } from "svelte";
 import { goto } from "$app/navigation";
 import AppDescription from "$lib/components/Description.svelte";
 import AppEntrance from "$lib/components/Entrance.svelte";
+import AppRecommendedEnvironment from "$lib/components/RecommendedEnvironment.svelte";
 import AccessLogRepository from "$lib/repositories/access_log";
 
 const repo = new AccessLogRepository();
@@ -25,6 +26,7 @@ onMount(async () => {
   </div>
 </div>
 <AppEntrance moveToHome={moveToHome} />
+<AppRecommendedEnvironment />
 
 <style>
   .marquee {


### PR DESCRIPTION
Issue #571 の対応。入口ページに推奨環境（IE5.5 / 800×600）の案内文を追加し、UA が IE 以外の場合は「推奨環境外」の警告を表示するようにした。