### PR TITLE
アクセスカウンターの専用ノード化（increment 対応）

### DIFF
--- a/src/lib/components/Counter.spec.ts
+++ b/src/lib/components/Counter.spec.ts
@@ -1,15 +1,15 @@
 import { render, waitFor } from "@testing-library/svelte";
 import { describe, expect, test, vi } from "vitest";
 import Component from "$lib/components/Counter.svelte";
-import AccessLogRepository from "$lib/repositories/access_log";
+import CounterRepository from "$lib/repositories/counter";
 
-vi.mock("../repositories/access_log");
+vi.mock("../repositories/counter");
 
 describe("Counter", () => {
 	test.each([0, 50, 1234, 99999, 654321])(
 		"%d が6桁で表示されている",
 		async (value) => {
-			const spy = vi.spyOn(AccessLogRepository.prototype, "count");
+			const spy = vi.spyOn(CounterRepository.prototype, "get");
 			spy.mockResolvedValue(value);
 			const { container } = render(Component);
 

--- a/src/lib/components/Counter.svelte
+++ b/src/lib/components/Counter.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 import { onMount } from "svelte";
-import AccessLogRepository from "$lib/repositories/access_log";
+import CounterRepository from "$lib/repositories/counter";
 
-const repo = new AccessLogRepository();
+const repo = new CounterRepository();
 
 let count = 0;
 $: counter = count.toString().padStart(6, "0");
 
 onMount(async () => {
-	count = await repo.count();
+	count = await repo.get();
 });
 </script>
 

--- a/src/lib/repositories/access_log.ts
+++ b/src/lib/repositories/access_log.ts
@@ -1,4 +1,4 @@
-import { get, getDatabase, push, ref } from "firebase/database";
+import { getDatabase, push, ref } from "firebase/database";
 import type { DatabaseReference } from "firebase/database";
 
 export default class AccessLogRepository {
@@ -6,10 +6,6 @@ export default class AccessLogRepository {
 
 	constructor() {
 		this.ref = ref(getDatabase(), "access_logs");
-	}
-
-	async count() {
-		return get(this.ref).then((snapshot) => Object.keys(snapshot.val()).length);
 	}
 
 	async create(userAgent: string) {

--- a/src/lib/repositories/counter.ts
+++ b/src/lib/repositories/counter.ts
@@ -1,0 +1,18 @@
+import { get, getDatabase, increment, ref, set } from "firebase/database";
+import type { DatabaseReference } from "firebase/database";
+
+export default class CounterRepository {
+	private ref: DatabaseReference;
+
+	constructor() {
+		this.ref = ref(getDatabase(), "counter");
+	}
+
+	async get() {
+		return get(this.ref).then((snapshot) => (snapshot.val() as number) ?? 0);
+	}
+
+	async increment() {
+		return set(this.ref, increment(1));
+	}
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,8 +5,10 @@ import AppDescription from "$lib/components/Description.svelte";
 import AppEntrance from "$lib/components/Entrance.svelte";
 import AppRecommendedEnvironment from "$lib/components/RecommendedEnvironment.svelte";
 import AccessLogRepository from "$lib/repositories/access_log";
+import CounterRepository from "$lib/repositories/counter";
 
 const repo = new AccessLogRepository();
+const counterRepo = new CounterRepository();
 
 const moveToHome = () => goto("/home");
 
@@ -14,6 +16,7 @@ onMount(async () => {
 	if (!(import.meta as any).env.DEV) {
 		const userAgent = window.navigator.userAgent;
 		await repo.create(userAgent).catch(console.error);
+		await counterRepo.increment().catch(console.error);
 	}
 });
 </script>

--- a/src/setup-test.ts
+++ b/src/setup-test.ts
@@ -3,8 +3,10 @@ import { beforeEach, vi } from "vitest";
 vi.mock("firebase/database", async () => ({
 	get: vi.fn(),
 	getDatabase: vi.fn(),
+	increment: vi.fn(),
 	push: vi.fn(),
 	ref: vi.fn(),
+	set: vi.fn(),
 }));
 
 beforeEach(() => {


### PR DESCRIPTION
### 概要

- Closes #574
- 現行の `AccessLogRepository.count()` は `access_logs` を全件取得して件数を数えており、アクセス数の増加に比例して読み取り量・表示速度が悪化する問題があった。RTDB の `increment()` による専用カウンターノードに置き換えて解消する。

### 対応内容

- `counter` ノードを新設し、`get` / `increment` を持つ `CounterRepository` を追加
- アクセス記録時（`+page.svelte`）に `counter` ノードを `increment()` で加算するよう変更
- `Counter` コンポーネントは `counter` ノードの値を参照するよう変更
- 不要になった `AccessLogRepository.count()`（全件取得方式）を削除
- `Counter.spec.ts` を新しいリポジトリ参照に合わせて修正
- RTDB セキュリティルールに `counter` ノードの `.validate`（数値・非負のみ許可）を追加

既存 `access_logs` 件数の `counter` への初期移行は、デプロイ後に Firebase コンソールもしくは CLI で手動実施予定（本 PR のスコープ外）。